### PR TITLE
Fix docker stop wrong command 

### DIFF
--- a/backupdate.sh
+++ b/backupdate.sh
@@ -267,7 +267,8 @@ script_update_check() {
 docker_stack_stop() {
     echo "Stopping Docker stack: <$stack_name>"
     cd "$working_dir" || exit
-    if docker compose ps --filter "status=running" | grep -q "$stack_name"; then
+    # check stack running, with at least one container running
+    if docker compose ls --quiet --filter "name=$stack_name" | grep -q "$stack_name"; then
         stack_running=true
         docker compose stop
     else


### PR DESCRIPTION
See #15

## Testing:

- compose stack `alpine`
    - container `alpine`
    - container `database-alpha`

| test | compose ps (old) | compose ls (new) |
|---|---|---|
| all containers running | ✔️ | ✔️ |
| all containers stopped | ✔️ | ✔️ |
| `alpine` container stopped | ❌ | ✔️ |

> Use of the previous command fails to stop the stacks containers. This occurs when only the container named `alpine` is stopped, but `database-alpha` is still running. Which results in an unwanted live backup of data.